### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ It is based on the Go `gofmt` command source code and the go `printer` package, 
 
 We have modified the `printer` code in the `pyprint` package to instead print out Python code.
 
-The `-gopy` flag generates [GoPy](https:://github.com/go-python/gopy) specific Python code, including:
+The `-gopy` flag generates [GoPy](https://github.com/go-python/gopy) specific Python code, including:
 
 * `nil` -> `go.nil`
 * `[]string{...}` -> `go.Slice_string([...])`  etc for int, float64, float32
 
-The `-gogi` flag generates [GoGi](https:://github.com/goki/gi) specific Python code, including:
+The `-gogi` flag generates [GoGi](https://github.com/goki/gi) specific Python code, including:
 
 * struct tags generate: `self.SetTags()` call, for the `pygiv.ClassViewObj` class, which then provides an automatic GUI view with tag-based formatting of struct fields.
 


### PR DESCRIPTION
Hi there,

In your README.md you are using :: ( double colons ), where it should be : ( one colon ) after https to get proper redirects.


```python
https:://github.com/go-python/gopy ⚔️  # Wrong
https://github.com/go-python/gopy 👌   # Correct
```

This pull request essentially fixes that.